### PR TITLE
Automatically publish sphinx doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,16 @@ script:
   - python setup.py install --user
   - make html -C doc
   - pytest test/ -s
+
+after_success:
+  - test "$TRAVIS_PULL_REQUEST" = "false" -a "$TRAVIS_BRANCH" = "master" || exit 0
+  - git clone https://${GH_TOKEN}github.com/anthony-nouy/anthony-nouy.github.io.git
+  - mkdir -p anthony-nouy.github.io/sphinx/${REPO_NAME}/${TRAVIS_BRANCH}
+  - cp -r doc/_build/html/* anthony-nouy.github.io/sphinx/${REPO_NAME}/${TRAVIS_BRANCH}
+  - cd anthony-nouy.github.io
+  #- touch .nojekyll
+  - git config user.email "support@travis-ci.com"
+  - git config user.name "Travis CI"
+  - git add -A .
+  - git commit -a -m "Travis build ${REPO_NAME} ${TRAVIS_BUILD_NUMBER}"
+  - git push --quiet origin master > /dev/null 2>&1


### PR DESCRIPTION
This allows to publish the sphinx doc to anthony-nouy.github.io/sphinx/tensap/master

This will need a few more steps after merge for travis to have the rights to push to anthony-nouy.github.io securely:

Step 1: generate an access token (check the "repo" box), this will be used to give travis the rights:
https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token

Step 2: encrypt the token into the .travis.yml: this will avoid to leak the token in travis logs and secure the access, (you will need to install the travis ruby module):
```
apt install ruby-dev
gem install travis --user
cd tensap
PATH=$HOME/.gem/ruby/2.5.0/bin:$PATH travis encrypt GH_TOKEN=###########################################
```
where ########## is your travis token
follow the intructions of the travis encrypt command:
```
Shell completion not installed. Would you like to install it now? |y| n
Detected repository as jschueller/tensap, is this correct? |yes| 
Please add the following to your .travis.yml file:

  secure: "gXbglLZ23M...iTw="
```

Step 3: Add the secure env to the .travis.yml file:
Just paste the string generated at the previous step, the .travis.yml should look like this:
```
...
  - git push --quiet origin master > /dev/null 2>&1

env:
  global:
    secure: "exGxIfCYRlG/1....tIf9k="
```





