### PR TITLE
Add code coverage 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 *.pyc
 __pycache__
+build
+dist
+tensap.egg-info
+coverage.xml
+.coverage
+.pytest_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ install:
   - wget -c --no-check-certificate https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -P /tmp
   - bash /tmp/Miniconda3-latest-Linux-x86_64.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
-  - conda install -y tensorflow scikit-learn pytest networkx matplotlib sphinx numpydoc
+  - conda install -y tensorflow scikit-learn pytest networkx matplotlib sphinx numpydoc pytest-cov codecov
 
 script:
   - python setup.py install --user
   - make html -C doc
-  - pytest test/ -s
+  - mv tensap tensap_code && pytest --cov-report=xml --cov=tensap --capture=no test && mv tensap_code tensap
 
 after_success:
   - test "$TRAVIS_PULL_REQUEST" = "false" -a "$TRAVIS_BRANCH" = "master" || exit 0
@@ -26,6 +26,8 @@ after_success:
   - git add -A .
   - git commit -a -m "Travis build ${REPO_NAME} ${TRAVIS_BUILD_NUMBER}"
   - git push --quiet origin master > /dev/null 2>&1
+  # Push the results back to codecov
+  - codecov
 
 env:
     global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: generic
 os: linux
+dist: xenial
 
 install:
   # conda

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: generic
+os: linux
 
 install:
   # conda

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: generic
-sudo: false
 
 install:
   # conda

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 [![Build Status](https://travis-ci.org/anthony-nouy/tensap.svg?branch=master)](https://travis-ci.org/anthony-nouy/tensap)
+[![codecov](https://codecov.io/gh/Gjacquenot/tensap/branch/master/graph/badge.svg)](https://codecov.io/gh/Gjacquenot/tensap)
 
 # tensap (Tensor Approximation Package)
 
-A Python package for the approximation of functions and tensors. 
+A Python package for the approximation of functions and tensors.
 
 tensap features low-rank tensors (including canonical, tensor-train and tree-based tensor formats or tree tensor networks), sparse tensors, polynomials, and allows the plug-in of other approximation tools. It provides different approximation methods based on interpolation, least-squares projection or statistical learning.
 

--- a/test/test_tutorials.py
+++ b/test/test_tutorials.py
@@ -1,16 +1,27 @@
-import subprocess
-import sys
 import glob
 import pytest
-import os
 import time
+import matplotlib
+import matplotlib.pyplot as plt
+matplotlib.use('Agg')
+
+
+def execfile(filepath, globals=None, locals=None):
+    if globals is None:
+        globals = {}
+    globals.update({
+        "__file__": filepath,
+        "__name__": "__main__",
+    })
+    with open(filepath, 'rb') as file:
+        exec(compile(file.read(), filepath, 'exec'), globals, locals)
+
 
 @pytest.mark.parametrize("f", glob.glob('tutorials/**/*.py', recursive=True))
 def test_tutorial(f):
     print(f"-- running {f}")
-    mpl_env = os.environ.copy()
-    mpl_env["MPLBACKEND"] = "agg"
     t0 = time.time()
-    subprocess.run([sys.executable, f], check=True, env=mpl_env)
+    execfile(f)
     dt = time.time() - t0
     print(f"-- {f} ran in {dt:.2f} s")
+    plt.close("all")


### PR DESCRIPTION
This pull request adds code coverage for tensap package based on tutorials execution. One can see a 60% code coverage, not bad at all for a non TDD project.

Basically, it:

- updates `pytest` command to activate code coverage
- updates test to launch all tutorials from (no more subprocess)
- uploads code coverage, an online service that let you explore which part of the code is covered.

Result is visible online here: https://codecov.io/gh/Gjacquenot/tensap

A badge has been added to the main Readme.md. One can click on it and access the report.

Once accepted, you have to:

- create an account on codecov.io to have ownership of generated reports (creation with Github credentials)
- update the badge URL to match your account

Guillaume
