### PR TITLE
CI: Install TF2 from pip on win32

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,10 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniforge-version: latest
+          python-version: 3.9
       - name: Build
         run: |
-          conda install -y tensorflow scikit-learn pytest networkx matplotlib
+          conda install -y scikit-learn pytest networkx matplotlib pip
+          pip install tensorflow
           python setup.py install
           pytest -s

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://github.com/openturns/otpod/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/openturns/otpod/actions/workflows/build.yml)
+[![Build Status](https://github.com/anthony-nouy/tensap/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/anthony-nouy/tensap/actions/workflows/build.yml)
 [![codecov](https://codecov.io/gh/anthony-nouy/tensap/branch/master/graph/badge.svg)](https://codecov.io/gh/anthony-nouy/tensap)
 [![Doc](https://readthedocs.org/projects/spack/badge/?version=latest)](https://anthony-nouy.github.io/sphinx/tensap/master/)
 


### PR DESCRIPTION
Seems tensorflow 2.x is not available on conda-forge for windows