### PR TITLE
Reformat sources

### DIFF
--- a/tensap/tensor_algebra/tensors/canonical_tensor.py
+++ b/tensap/tensor_algebra/tensors/canonical_tensor.py
@@ -508,7 +508,7 @@ class CanonicalTensor:
             dims = np.arange(self.order)
         else:
             dims = np.atleast_1d(dims)
-        
+
         a = [np.ones(self.shape[i]) for i in dims]
 
         return self.tensor_vector_product(a, dims)

--- a/tensap/tensor_algebra/tensors/full_tensor.py
+++ b/tensap/tensor_algebra/tensors/full_tensor.py
@@ -458,7 +458,7 @@ class FullTensor:
             The squeezed tensor.
 
         """
-        
+
         if dims is not None:
             dims = tuple(np.atleast_1d(dims))
 

--- a/tensap/tensor_algebra/tensors/tree_based_tensor.py
+++ b/tensap/tensor_algebra/tensors/tree_based_tensor.py
@@ -522,14 +522,14 @@ class TreeBasedTensor:
             A representation of the TreeBasedTensor as a tensap.FullTensor.
 
         """
-        
+
         tree = self.tree
         if self.order == 1:
-            a =  self.tensors[tree.root - 1]
-            if a.order==2:
+            a = self.tensors[tree.root - 1]
+            if a.order == 2:
                 a = a.squeeze(1)
             return a
-        
+
         tensors = np.array(self.tensors)
 
         for level in np.arange(np.max(tree.level), -1, -1):
@@ -550,12 +550,12 @@ class TreeBasedTensor:
                         dims = np.concatenate((dims, tree.dims[child - 1]))
                 tree.dims[nod - 1] = dims
 
-        #if self.ranks[tree.root - 1] > 1:
+        # if self.ranks[tree.root - 1] > 1:
         #    dims = np.concatenate((dims, [self.order]))
         tensor = tensors[tree.root - 1]
         if tensor.order > self.order:
-            dimsextra = np.arange(self.order,tensor.order)
-            dims = np.concatenate((dims,dimsextra))
+            dimsextra = np.arange(self.order, tensor.order)
+            dims = np.concatenate((dims, dimsextra))
         if tensor.order > 1:
             tensor = tensor.itranspose(dims)
         return tensor
@@ -1558,7 +1558,7 @@ class TreeBasedTensor:
                                 tensors[child - 1], num
                             )
                             tensors[child - 1] = []
-                    if np.any(children_r):        
+                    if np.any(children_r):
                         tensors[nod - 1] = tensors[nod - 1].squeeze(
                             np.nonzero(children_r)[0].tolist()
                         )


### PR DESCRIPTION
Sources must pass the flake8 linter else the CI fails
One can use black to automatically reformat the whole tree and manually fix the remaining few issues