### PR TITLE
Poincare learning: minor fixes an features

### DIFF
--- a/tensap/approximation/bases/functional_bases.py
+++ b/tensap/approximation/bases/functional_bases.py
@@ -349,7 +349,7 @@ class FunctionalBases:
 
         """
         out = deepcopy(self)
-        out.bases = [x.derivative(m) for x, m in zip(self.bases, n)]
+        out.bases = np.array([x.derivative(m) for x, m in zip(self.bases, n)])
         return out
 
     def random(self, *args, **kwargs):

--- a/tensap/approximation/bases/sparse_tensor_product_functional_basis.py
+++ b/tensap/approximation/bases/sparse_tensor_product_functional_basis.py
@@ -238,6 +238,7 @@ class SparseTensorProductFunctionalBasis(tensap.FunctionalBasis):
     def derivative(self, n):
         out = deepcopy(self)
         out.bases = out.bases.derivative(n)
+        out.is_orthonormal = np.all([x.is_orthonormal for x in out.bases.bases])
         return out
 
     def adaptation_path(self, p=1):

--- a/tensap/approximation/bases/sparse_tensor_product_functional_basis.py
+++ b/tensap/approximation/bases/sparse_tensor_product_functional_basis.py
@@ -241,6 +241,31 @@ class SparseTensorProductFunctionalBasis(tensap.FunctionalBasis):
         out.is_orthonormal = np.all([x.is_orthonormal for x in out.bases.bases])
         return out
 
+    def eval_jacobian(self, x):
+        """
+        Compute evaluations of the Jacobian matrix of self at points x.
+
+        Parameters
+        ----------
+        x : numpy.ndarray
+            The input points.
+
+        Returns
+        -------
+        out : numpy.ndarray
+            Evaluations of the Jacobian matrix of self.
+            out[k,i,j] is the evaluation of df_i/dx_j at the k-th sample.
+
+        """
+        dnHx_lst = []
+        for ind in range(self.length()):
+            n = self.length() * [0]
+            n[ind] = 1
+            dnHx_i = self.eval_derivative(n, x)[:, :, None]  # add an axis to concatenate
+            dnHx_lst.append(dnHx_i)
+        out = np.concatenate(dnHx_lst, axis=2)
+        return out
+
     def adaptation_path(self, p=1):
         """
         Create an adaptation path associated with increasing p-norm of

--- a/tensap/approximation/bases/sparse_tensor_product_functional_basis.py
+++ b/tensap/approximation/bases/sparse_tensor_product_functional_basis.py
@@ -311,6 +311,24 @@ class SparseTensorProductFunctionalBasis(tensap.FunctionalBasis):
                 M *= G[i][np.ix_(ind[:, i], ind[:, i])]
         return M
 
+    def gram_matrix_h1_0(self):
+        """
+        Return the gram matrix of the basis with respect to the L2(H1_0) inner product.
+        In other words G[i,j] is E(grad(Bi)(X).T @ grad(Bj)(X)).
+
+        Returns
+        -------
+        G : numpy.ndarray
+            The gram matrix of the basis with respect to the L2(H1_0) inner product.
+
+        """
+        ndim, cardinal = self.ndim(), self.cardinal()
+        G = np.zeros((cardinal, cardinal))
+        for i in range(ndim):
+            didB = self.derivative([1 * (j == i) for j in range(ndim)])
+            G = G + didB.gram_matrix()
+        return G
+
     def plot_multi_indices(self, *args):
         """
         PLot the multi-index set of the object.

--- a/tensap/approximation/bases/sparse_tensor_product_functional_basis.py
+++ b/tensap/approximation/bases/sparse_tensor_product_functional_basis.py
@@ -278,7 +278,7 @@ class SparseTensorProductFunctionalBasis(tensap.FunctionalBasis):
         if self.is_orthonormal:
             M = speye(self.indices.cardinal())
         else:
-            G = self.bases.gram_matrix()
+            G = self.bases.gram_matrices()
             ind = self.indices.array
             M = G[0][np.ix_(ind[:, 0], ind[:, 0])]
             for i in np.arange(1, ind.shape[1]):

--- a/tensap/approximation/bases/sub_functional_basis.py
+++ b/tensap/approximation/bases/sub_functional_basis.py
@@ -163,6 +163,26 @@ class SubFunctionalBasis(tensap.FunctionalBasis):
         d_f.underlying_basis = self.underlying_basis.derivative(n)
         return d_f
 
+    def eval_jacobian(self, x):
+        """
+        Compute evaluations of the Jacobian matrix of self at points x.
+
+        Parameters
+        ----------
+        x : numpy.ndarray
+            The input points.
+
+        Returns
+        -------
+        out : numpy.ndarray
+            Evaluations of the Jacobian matrix of self.
+            out[k,i,j] is the evaluation of df_i/dx_j at the k-th sample.
+
+        """
+        jac = self.underlying_basis.eval_jacobian(x)
+        out = np.einsum('ij,ajk', self.basis, jac)
+        return out
+
     def mean(self):
         return np.matmul(self.underlying_basis.mean(), self.basis)
 

--- a/tensap/approximation/bases/sub_functional_basis.py
+++ b/tensap/approximation/bases/sub_functional_basis.py
@@ -165,3 +165,6 @@ class SubFunctionalBasis(tensap.FunctionalBasis):
 
     def mean(self):
         return np.matmul(self.underlying_basis.mean(), self.basis)
+
+    def gram_matrix(self):
+        return self.basis.T @ self.underlying_basis.gram_matrix() @ self.basis

--- a/tensap/approximation/bases/sub_functional_basis.py
+++ b/tensap/approximation/bases/sub_functional_basis.py
@@ -188,3 +188,6 @@ class SubFunctionalBasis(tensap.FunctionalBasis):
 
     def gram_matrix(self):
         return self.basis.T @ self.underlying_basis.gram_matrix() @ self.basis
+
+    def gram_matrix_h1_0(self):
+        return self.basis.T @ self.underlying_basis.gram_matrix_h1_0() @ self.basis


### PR DESCRIPTION
Fix - Orthonormality check for `SparseTensorProductFunctionalBasis.derivative()` method. 
Fix - `FunctionalBases.derivative(n).bases` is now a `numpy.ndarray` instead of a `list`, allowing indexing with array-like objects as done in multiple other methods.
Fix - Adapt `SparseTensorProductFunctionalBasis.gram_matrix()` method to the refactoring from 39b500de6fd6e0b4275a9dcccb972ba0b866ae38.
Feat - Implemented `gram_matrix()` for `SubFunctionalBasis` class.
Feat - Implemented `eval_jacobian()` and `gram_matrix_h1_0()` for `SparseTensorProductFunctionalBasis` and `SubFunctionalBasis` classes.